### PR TITLE
Send item details when adding an annotation.

### DIFF
--- a/src/components/AnnotationTool.vue
+++ b/src/components/AnnotationTool.vue
@@ -308,7 +308,10 @@ export default {
           })
           const userAnnotation = {
             resource: this.annotationEntry['resourceId'],
-            item: this.annotationEntry['featureId'],
+            item: Object.assign({id: this.annotationEntry['featureId']},
+                    Object.fromEntries(
+                      Object.entries(this.annotationEntry)
+                            .filter(([key]) => ['label', 'models'].includes(key)))),
             body: {
               evidence: evidenceURLs,
               comment: this.comment,

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1560,7 +1560,7 @@ export default {
                   // Only clicked connection data will be added
                   let nodeLabel = data.label ? data.label : `Feature ${data.id}`
                   // only the linestring will have connection at the current stage
-                  if (nodeLabel && this.activeDrawTool === 'LineString') {
+                  if (this.activeDrawTool === 'LineString') {
                     this.connectionEntry[data.featureId] = Object.assign({label: nodeLabel},
                       Object.fromEntries(
                         Object.entries(data)

--- a/src/components/FlatmapVuer.vue
+++ b/src/components/FlatmapVuer.vue
@@ -1564,7 +1564,8 @@ export default {
                     this.connectionEntry[data.featureId] = Object.assign({label: nodeLabel},
                       Object.fromEntries(
                         Object.entries(data)
-                              .filter(([key]) => ['featureId', 'models'].includes(key))))
+                              .filter(([key]) => ['featureId', 'models'].includes(key))
+                              .map(([key, value]) => [(key === 'featureId') ? 'id' : key, value])))
                   }
                 }
               }


### PR DESCRIPTION
This:
1.  Sends `label` and `models` along with an item's `id` when adding an item.
2. Uses `id` instead of `featureId` when describing connectivity nodes.

The response from `itemAnnotations()` (line 261 of AnnotationTool.vue) now has full item details in the `item` field so you will need to update code that uses the response accordingly.
